### PR TITLE
fix: Strip out all non-alpha numeric characters in processed names

### DIFF
--- a/src/utility.ts
+++ b/src/utility.ts
@@ -23,10 +23,14 @@ export const processFieldName = (name: string): string => {
 };
 
 export const snakeToCamelCase = (name: string): string => {
-    return name.replace(/([-_][a-z])/gi, ($1) => {
-        return $1.toUpperCase().replace("-", "").replace("_", "");
-    });
-};
+    return name
+        // First, replace any sequence of non-alphanumeric characters with a single underscore
+        .replace(/[^a-zA-Z0-9]+/g, '_')
+        // Then, convert to camelCase by capitalizing the character following an underscore
+        .replace(/_([a-z])/gi, ($1) => $1.toUpperCase().replace('_', ''))
+        // Ensure the first character is lowercase
+        .replace(/^([A-Z])/, ($1) => $1.toLowerCase())
+}
 
 export const indentSwiftCode = (code: string, spaces: number = 4): string => {
     const lines = code.split("\n");


### PR DESCRIPTION
Fixes issues where enum cases generate invalid swift code:

ie. was getting `case image/jpeg = "image/jpeg"`, now get `case imageJpeg = "image/jpeg"`