### PR TITLE
Fixing single path procedure calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class AppRouter: TRPCClientData {
 
         /// Fetches a user by ID.
         func get(input: GetInputType) async throws -> User {
-            return try await TRPCClient.shared.sendQuery(url: url.appendingPathComponent("get"), middlewares: middlewares, input: input)
+            return try await TRPCClient.shared.sendQuery(url: url.appendingPathExtension("get"), middlewares: middlewares, input: input)
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class AppRouter: TRPCClientData {
 
         /// Fetches a user by ID.
         func get(input: GetInputType) async throws -> User {
-            return try await TRPCClient.shared.sendQuery(url: url.appendingPathExtension("get"), middlewares: middlewares, input: input)
+            return try await TRPCClient.shared.sendQuery(url: url.appendingPathComponent("get"), middlewares: middlewares, input: input)
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trpc-swift",
-    "version": "0.1.30",
+    "version": "0.1.32",
     "description": "Generates Swift clients and models from tRPC routers.",
     "repository": "https://github.com/calasanmarko/trpc-swift.git",
     "author": "Marko Calasan <calasanmarko@hotmail.com>",

--- a/src/generators/router.ts
+++ b/src/generators/router.ts
@@ -80,7 +80,7 @@ export const trpcStructureToSwiftClass = (name: string, structure: TRPCStructure
         if (state.routeDepth === 1) {
             swiftClass += `clientData.url.appendingPathComponent("${name}")\n`;
         } else {
-            swiftClass += `clientData.url.appendingPathComponent("${name}")\n`;
+            swiftClass += `clientData.url.appendingPathExtension("${name}")\n`;
         }
         swiftClass += "}\n\n";
         swiftClass += "fileprivate var middlewares: [TRPCMiddleware] {\n";
@@ -184,16 +184,17 @@ const trpcProcedureToSwiftMethodAndLocalModels = (name: string, procedure: Gener
             swiftMethod += " {\n";
         }
 
+        const pathMethod = state.routeDepth === 0 ? "appendingPathComponent" : "appendingPathExtension";
         if (procedure._def.query) {
             swiftMethod += `${
                 hasOutput ? "return" : "let _: TRPCClient.EmptyObject ="
-            } try await TRPCClient.shared.sendQuery(url: url.appendingPathComponent("${name}"), middlewares: middlewares, input: ${
+            } try await TRPCClient.shared.sendQuery(url: url.${pathMethod}("${name}"), middlewares: middlewares, input: ${
                 addedInput ? "input" : "TRPCClient.EmptyObject()"
             })\n`;
         } else if (procedure._def.mutation) {
             swiftMethod += `${
                 hasOutput ? "return" : "let _: TRPCClient.EmptyObject ="
-            } try await TRPCClient.shared.sendMutation(url: url.appendingPathComponent("${name}"), middlewares: middlewares, input: ${
+            } try await TRPCClient.shared.sendMutation(url: url.${pathMethod}("${name}"), middlewares: middlewares, input: ${
                 addedInput ? "input" : "TRPCClient.EmptyObject()"
             })\n`;
         } else {

--- a/src/generators/router.ts
+++ b/src/generators/router.ts
@@ -80,7 +80,7 @@ export const trpcStructureToSwiftClass = (name: string, structure: TRPCStructure
         if (state.routeDepth === 1) {
             swiftClass += `clientData.url.appendingPathComponent("${name}")\n`;
         } else {
-            swiftClass += `clientData.url.appendingPathExtension("${name}")\n`;
+            swiftClass += `clientData.url.appendingPathComponent("${name}")\n`;
         }
         swiftClass += "}\n\n";
         swiftClass += "fileprivate var middlewares: [TRPCMiddleware] {\n";
@@ -187,13 +187,13 @@ const trpcProcedureToSwiftMethodAndLocalModels = (name: string, procedure: Gener
         if (procedure._def.query) {
             swiftMethod += `${
                 hasOutput ? "return" : "let _: TRPCClient.EmptyObject ="
-            } try await TRPCClient.shared.sendQuery(url: url.appendingPathExtension("${name}"), middlewares: middlewares, input: ${
+            } try await TRPCClient.shared.sendQuery(url: url.appendingPathComponent("${name}"), middlewares: middlewares, input: ${
                 addedInput ? "input" : "TRPCClient.EmptyObject()"
             })\n`;
         } else if (procedure._def.mutation) {
             swiftMethod += `${
                 hasOutput ? "return" : "let _: TRPCClient.EmptyObject ="
-            } try await TRPCClient.shared.sendMutation(url: url.appendingPathExtension("${name}"), middlewares: middlewares, input: ${
+            } try await TRPCClient.shared.sendMutation(url: url.appendingPathComponent("${name}"), middlewares: middlewares, input: ${
                 addedInput ? "input" : "TRPCClient.EmptyObject()"
             })\n`;
         } else {


### PR DESCRIPTION
single path procedures were getting called with no path because the use of the use of `URL.appendingPathExtension` function. 
it is not intended to set the last path component, but only the file extension (ie `.html`) of the last path component. replacing this with `appending(path:)` or `appendingPathComponent` fixes the issue

source: https://developer.apple.com/documentation/foundation/nsurl/1410208-pathextension

I have confirmed that is branch builds